### PR TITLE
updated reads-per-batch options

### DIFF
--- a/q2_clawback/_clawback.py
+++ b/q2_clawback/_clawback.py
@@ -97,7 +97,7 @@ def generate_class_weights(
 def assemble_weights_from_Qiita(
         ctx, classifier, reference_taxonomy, reference_sequences,
         metadata_value, context, unobserved_weight=1e-6, normalise=False,
-        metadata_key='sample_type', n_jobs=1, reads_per_batch=0,
+        metadata_key='sample_type', n_jobs=1, reads_per_batch='auto',
         allow_weight_outside_reference=False):
     samples, = ctx.get_action('clawback', 'fetch_Qiita_samples')(
         metadata_value=metadata_value, context=context,

--- a/q2_clawback/plugin_setup.py
+++ b/q2_clawback/plugin_setup.py
@@ -6,7 +6,8 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime2.plugin import Plugin, List, Str, Float, Bool, Int, Citations
+from qiime2.plugin import (Plugin, List, Str, Float, Bool, Int, Citations,
+                           Range, Choices)
 from q2_types.feature_table import FeatureTable, RelativeFrequency, Frequency
 from q2_types.feature_data import FeatureData, Taxonomy, Sequence
 from q2_feature_classifier._taxonomic_classifier import TaxonomicClassifier
@@ -138,14 +139,15 @@ plugin.pipelines.register_function(
     inputs={'classifier': TaxonomicClassifier,
             'reference_taxonomy': FeatureData[Taxonomy],
             'reference_sequences': FeatureData[Sequence]},
-    parameters={'metadata_value': List[Str],
-                'context': Str,
-                'unobserved_weight': Float,
-                'normalise': Bool,
-                'metadata_key': Str,
-                'n_jobs': Int,
-                'reads_per_batch': Int,
-                'allow_weight_outside_reference': Bool},
+    parameters={
+        'metadata_value': List[Str],
+        'context': Str,
+        'unobserved_weight': Float,
+        'normalise': Bool,
+        'metadata_key': Str,
+        'n_jobs': Int,
+        'reads_per_batch': Int % Range(1, None) | Str % Choices(['auto']),
+        'allow_weight_outside_reference': Bool},
     outputs=[('class_weight', FeatureTable[RelativeFrequency])],
     name='Assemble weights from Qiita for use with q2-feature-classifier',
     description=('Download SV results from Qiita, classify the SVs, use the '


### PR DESCRIPTION
See original error report [here](https://forum.qiime2.org/t/reference-db-compatibility-silva-138-138-1/21913/7?u=nicholas_bokulich)

Looks like the parameter option was a bit outdated, since breaking changes were made upstream in q2-feature-classifier a while back.

Did not have time to test locally, so hopefully your CI tests cover this ;)